### PR TITLE
Remove an unused pragma restore branch

### DIFF
--- a/Item.Mutagen.Bestial.cs
+++ b/Item.Mutagen.Bestial.cs
@@ -131,6 +131,5 @@ public static class ItemMutagenBestial
           
        
 
-        #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Item.Mutagen.Drakeheart.cs
+++ b/Item.Mutagen.Drakeheart.cs
@@ -164,6 +164,5 @@ public static class ItemMutagenDrakeheart
             });
        
 
-        #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Item.Mutagen.Energy.cs
+++ b/Item.Mutagen.Energy.cs
@@ -298,6 +298,5 @@ public static class ItemMutagenEnergy
           
        
 
-        #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Item.Mutagen.Juggarnaut.cs
+++ b/Item.Mutagen.Juggarnaut.cs
@@ -122,6 +122,5 @@ public static class ItemMutagenJuggernaut
           
        
 
-        #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Item.Mutagen.Serene.cs
+++ b/Item.Mutagen.Serene.cs
@@ -139,6 +139,5 @@ public static class ItemMutagenSerene
           
        
 
-        #pragma warning restore CS0618 // Type or member is obsolete
     }
 }


### PR DESCRIPTION
I was looking for obsoletion warnings by searching for the string "0618" to see if any warnings were suppressed and these lines, while not suppressing anything anymore, came up.

This PR cleans up those unused lines.