### PR TITLE
Fix Animated Assault so that it properly takes damage bonuses into account

### DIFF
--- a/Spell.AnimatedAssault.cs
+++ b/Spell.AnimatedAssault.cs
@@ -110,8 +110,7 @@ public class SpellAnimatedAssualt
                 if (defender == null){return;}
                 int dmgdice = (int) Math.Floor (spell.SpellLevel/2.0);
                   CheckResult checkResult = CommonSpellEffects.RollSpellSavingThrow(defender, spell, Defense.Reflex);
-                  DiceFormula damage = Checks.ModifyDamageFromBasicSave(DiceFormula.FromText(dmgdice +"d10", spell.Name), checkResult);
-                  await creature.DealDirectDamage(spell, damage, defender, checkResult, DamageKind.Bludgeoning);
+                  await CommonSpellEffects.DealBasicDamage(spell, spell.Owner, defender, checkResult, DiceFormula.FromText(dmgdice +"d10", spell.Name), DamageKind.Bludgeoning);
               }
           });
                     


### PR DESCRIPTION
The method `Checks.ModifyDamageFromBasicSave` is now meant to be used very little if at all, and only for persistent damage.

Instead, standard damage should use `CommonSpellEffects.DealBasicDamage` or create the damage event itself with the `DoubleDamage` property set. That will ensure the proper sequencing of effects, such as making sure that bonuses to damage occur before halving or multiplying due to a save or a critical failure.