### PR TITLE
Replace .HasLineOfEffectTo() by .HasLineOfEffectToIgnoreLesser() for performance and because of deprecation

### DIFF
--- a/Misc/Actions.Leap.cs
+++ b/Misc/Actions.Leap.cs
@@ -51,7 +51,7 @@ public static class ActionLeap
                                         }
 
                                         if (nullable.GetValueOrDefault() <= num & nullable.HasValue)
-                                            if (caster.Occupies.HasLineOfEffectTo(tile) <= CoverKind.Lesser)
+                                            if (caster.Occupies.HasLineOfEffectToIgnoreLesser(tile) <= CoverKind.Lesser)
                                             {
                                                 return true;
                                             }


### PR DESCRIPTION
Replace .HasLineOfEffectTo() by .HasLineOfEffectToIgnoreLesser() because in this case, the results are the same: you don't care whether the target has lesser cover, and the method .HasLineOfEffectToIgnoreLesser() has caching meaning that it is much faster, and so this will improve performance. 

In addition, the method .HasLineOfEffectTo() will become deprecated in version 2.45.