### PR TITLE
Fix exceptions in character builder for characters with an archetype but no class or a class that matches their archetype

### DIFF
--- a/Archetypes/Archertype.Barbarian.cs
+++ b/Archetypes/Archertype.Barbarian.cs
@@ -107,7 +107,7 @@ public static class ArchetypeBarbarian
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, BarbarianArchetypeTrait })
             .WithCustomName("Barbarian Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Strength) >= 14 && values.FinalAbilityScores.TotalScore(Ability.Constitution) >= 14, "You must have at least 14 Strength and Constitution .")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Barbarian, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Barbarian, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {
@@ -178,7 +178,7 @@ public static class ArchetypeBarbarian
               .WithPrerequisite((CalculatedCharacterSheetValues values) => values.AllFeats.Contains<Feat>(BarbarianDedicationFeat), "You must have the Barbarian Dedication feat.")
               .WithPrerequisite((CalculatedCharacterSheetValues values) =>
 
-              values.Sheet?.Class.ClassTrait != Trait.Barbarian
+              values.Sheet.Class?.ClassTrait != Trait.Barbarian
 
 
               , "You have a class granting more than Hit Points per level than 10 + your Constitution modifier")

--- a/Archetypes/Archertype.Bard.cs
+++ b/Archetypes/Archertype.Bard.cs
@@ -37,10 +37,11 @@ public static class ArchetypeBard
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, BardArchetypeTrait, FeatArchetype.ArchetypeSpellcastingTrait })
             .WithCustomName("Bard Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Charisma) >= 14, "You must have at least 14 Charizzma")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Bard, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Bard, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
-    {
+            {
+                if (sheet.Sheet.Class?.ClassTrait == Trait.Bard) return; // Do nothing if you're already this class. This feat will be removed in the next cycle due to a failed prerequisite anyway.
 
 
       Trait spellList = Trait.Occult;

--- a/Archetypes/Archertype.Cleric.cs
+++ b/Archetypes/Archertype.Cleric.cs
@@ -156,7 +156,7 @@ public static class ArchetypeCleric
             dietylist)
             .WithCustomName("Cleric Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Wisdom) >= 14, "You must have at least 14 wisdom")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Cleric, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Cleric, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {

--- a/Archetypes/Archertype.Fighter.cs
+++ b/Archetypes/Archertype.Fighter.cs
@@ -42,7 +42,7 @@ public static class ArchetypeFighter
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, FighterArchetypeTrait })
             .WithCustomName("Fighter Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Strength) >= 14 && values.FinalAbilityScores.TotalScore(Ability.Dexterity) >= 14, "You must have at least 14 Strength and Dexterity.")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Fighter, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Fighter, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {
@@ -106,9 +106,9 @@ public static class ArchetypeFighter
               .WithCustomName("Fighter Resiliency")
               .WithPrerequisite((CalculatedCharacterSheetValues values) => values.AllFeats.Contains<Feat>(FighterDedicationFeat), "You must have the Fighter Dedication feat.")
               .WithPrerequisite((CalculatedCharacterSheetValues values) =>
-              values.Sheet?.Class.ClassTrait != Trait.Ranger &&
-              values.Sheet?.Class.ClassTrait != Trait.Barbarian &&
-              values.Sheet?.Class.ClassTrait != Trait.Monk
+              values.Sheet.Class?.ClassTrait != Trait.Ranger &&
+              values.Sheet.Class?.ClassTrait != Trait.Barbarian &&
+              values.Sheet.Class?.ClassTrait != Trait.Monk
 
               , "You have a class granting more than Hit Points per level than 8 + your Constitution modifier")
               .WithOnCreature((CalculatedCharacterSheetValues sheet, Creature cr) =>

--- a/Archetypes/Archertype.Monk.cs
+++ b/Archetypes/Archertype.Monk.cs
@@ -36,7 +36,7 @@ public static class ArchetypeMonk
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, MonkArchetypeTrait })
             .WithCustomName("Monk Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Strength) >= 14 && values.FinalAbilityScores.TotalScore(Ability.Dexterity) >= 14, "You must have at least 14 Strength and Dexterity.")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Monk, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Monk, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {
@@ -93,9 +93,9 @@ public static class ArchetypeMonk
               .WithCustomName("Monk Resiliency")
               .WithPrerequisite((CalculatedCharacterSheetValues values) => values.AllFeats.Contains<Feat>(MonkDedicationFeat), "You must have the Monk Dedication feat.")
               .WithPrerequisite((CalculatedCharacterSheetValues values) =>
-              values.Sheet?.Class.ClassTrait != Trait.Ranger &&
-              values.Sheet?.Class.ClassTrait != Trait.Barbarian &&
-              values.Sheet?.Class.ClassTrait != Trait.Fighter
+              values.Sheet.Class?.ClassTrait != Trait.Ranger &&
+              values.Sheet.Class?.ClassTrait != Trait.Barbarian &&
+              values.Sheet.Class?.ClassTrait != Trait.Fighter
 
               , "You have a class granting more than Hit Points per level than 8 + your Constitution modifier")
               .WithOnCreature((CalculatedCharacterSheetValues sheet, Creature cr) =>

--- a/Archetypes/Archertype.Psychic.cs
+++ b/Archetypes/Archertype.Psychic.cs
@@ -59,10 +59,11 @@ public static class ArchetypePsychic
             )
             .WithCustomName("Psychic Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Charisma) >= 14 || values.FinalAbilityScores.TotalScore(Ability.Intelligence) >= 14, "You must have at least Intelligence 14, or Charisma 14.")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Psychic, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Psychic, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {
+        if (sheet.Sheet.Class?.ClassTrait == Trait.Psychic) return; // Do nothing if you're already this class. This feat will be removed in the next cycle due to a failed prerequisite anyway.
 
       Ability CastingAbility = Ability.Intelligence;
 

--- a/Archetypes/Archertype.Ranger.cs
+++ b/Archetypes/Archertype.Ranger.cs
@@ -39,7 +39,7 @@ public static class ArchetypeRanger
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, RangerArchetypeTrait })
             .WithCustomName("Ranger Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Dexterity) >= 14, "You must have at least 14 Dexterity.")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Ranger, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Ranger, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {
@@ -133,9 +133,9 @@ public static class ArchetypeRanger
             .WithCustomName("Ranger Resiliency")
             .WithPrerequisite((CalculatedCharacterSheetValues values) => values.AllFeats.Contains<Feat>(RangerDedicationFeat), "You must have the Ranger Dedication feat.")
             .WithPrerequisite((CalculatedCharacterSheetValues values) =>
-            values.Sheet?.Class.ClassTrait != Trait.Monk &&
-            values.Sheet?.Class.ClassTrait != Trait.Barbarian &&
-            values.Sheet?.Class.ClassTrait != Trait.Fighter
+            values.Sheet.Class?.ClassTrait != Trait.Monk &&
+            values.Sheet.Class?.ClassTrait != Trait.Barbarian &&
+            values.Sheet.Class?.ClassTrait != Trait.Fighter
 
             , "You have a class granting more than Hit Points per level than 8 + your Constitution modifier")
             .WithOnCreature((CalculatedCharacterSheetValues sheet, Creature cr) =>

--- a/Archetypes/Archertype.Rogue.cs
+++ b/Archetypes/Archertype.Rogue.cs
@@ -38,7 +38,7 @@ public static class ArchetypeRogue
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, RogueArchetypeTrait })
             .WithCustomName("Rogue Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Dexterity) >= 14, "You must have at least 14 Dexterity.")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Rogue, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Rogue, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {

--- a/Archetypes/Archertype.Sorcerer.cs
+++ b/Archetypes/Archertype.Sorcerer.cs
@@ -58,7 +58,7 @@ public static class ArchetypeSorcerer
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, SorcererArchetypeTrait, FeatArchetype.ArchetypeSpellcastingTrait }, bloodlinelist)
             .WithCustomName("Sorcerer Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Charisma) >= 14, "You must have at least 14 Charisma")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Sorcerer, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Sorcerer, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {
@@ -154,6 +154,7 @@ public static class ArchetypeSorcerer
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
 {
+    
   SpellRepertoire repertoire;
   if (sheet.SpellRepertoires.TryGetValue(Trait.Sorcerer, out repertoire) == false)
   {

--- a/Archetypes/Archertype.Wizard.cs
+++ b/Archetypes/Archertype.Wizard.cs
@@ -37,7 +37,7 @@ public static class ArchetypeWizard
       values.AddFocusSpellAndFocusPoint(Trait.Wizard, Ability.Intelligence, FocusSpell);
     })
   .WithCustomName(name)
-  .WithRulesBlockForSpell(FocusSpell)
+  .WithRulesBlockForSpell(FocusSpell, Trait.Wizard)
   .WithIllustration(modernSpellTemplate.Illustration);
     //. modernSpellTemplate.Name.ToLower() 
 

--- a/Archetypes/Archertype.Wizard.cs
+++ b/Archetypes/Archertype.Wizard.cs
@@ -61,7 +61,7 @@ public static class ArchetypeWizard
             new Trait[] { FeatArchetype.DedicationTrait, FeatArchetype.ArchetypeTrait, DawnniExpanded.DETrait, WizardArchetypeTrait, FeatArchetype.ArchetypeSpellcastingTrait })
             .WithCustomName("Wizard Dedication")
             .WithPrerequisite(values => values.FinalAbilityScores.TotalScore(Ability.Intelligence) >= 14, "You must have at least 14 inteligence")
-            .WithPrerequisite(values => values.Sheet?.Class.ClassTrait != Trait.Wizard, "You already have this archetype as a main class.")
+            .WithPrerequisite(values => values.Sheet.Class?.ClassTrait != Trait.Wizard, "You already have this archetype as a main class.")
             .WithOnSheet(delegate (CalculatedCharacterSheetValues sheet)
 
     {

--- a/Archetypes/Archertype.Wizard.cs
+++ b/Archetypes/Archertype.Wizard.cs
@@ -37,7 +37,7 @@ public static class ArchetypeWizard
       values.AddFocusSpellAndFocusPoint(Trait.Wizard, Ability.Intelligence, FocusSpell);
     })
   .WithCustomName(name)
-  .WithRulesBlockForSpell(FocusSpell, Trait.Wizard)
+  .WithRulesBlockForSpell(FocusSpell)
   .WithIllustration(modernSpellTemplate.Illustration);
     //. modernSpellTemplate.Name.ToLower() 
 

--- a/Archetypes/Archetype.Bloodline.cs
+++ b/Archetypes/Archetype.Bloodline.cs
@@ -48,7 +48,7 @@ public class ArchetypeBloodline : Feat
     this.focusSpell = focusSpell;
     this.grantedLevel1Spell = grantedLevel1Spell;
     this.grantedLevel2Spell = grantedLevel2Spell;
-    this.WithRulesBlockForSpell(focusSpell);
+    this.WithRulesBlockForSpell(focusSpell, Trait.Sorcerer);
     this.OnSheet = (Action<CalculatedCharacterSheetValues>)(sheet =>
     {
         if (sheet.Sheet.Class?.ClassTrait == Trait.Sorcerer) return; // Do nothing if you're already this class. This feat will be removed in the next cycle due to a failed prerequisite anyway.

--- a/Archetypes/Archetype.Bloodline.cs
+++ b/Archetypes/Archetype.Bloodline.cs
@@ -48,7 +48,7 @@ public class ArchetypeBloodline : Feat
     this.focusSpell = focusSpell;
     this.grantedLevel1Spell = grantedLevel1Spell;
     this.grantedLevel2Spell = grantedLevel2Spell;
-    this.WithRulesBlockForSpell(focusSpell, Trait.Sorcerer);
+    this.WithRulesBlockForSpell(focusSpell);
     this.OnSheet = (Action<CalculatedCharacterSheetValues>)(sheet =>
     {
         if (sheet.Sheet.Class?.ClassTrait == Trait.Sorcerer) return; // Do nothing if you're already this class. This feat will be removed in the next cycle due to a failed prerequisite anyway.

--- a/Archetypes/Archetype.Bloodline.cs
+++ b/Archetypes/Archetype.Bloodline.cs
@@ -51,6 +51,7 @@ public class ArchetypeBloodline : Feat
     this.WithRulesBlockForSpell(focusSpell);
     this.OnSheet = (Action<CalculatedCharacterSheetValues>)(sheet =>
     {
+        if (sheet.Sheet.Class?.ClassTrait == Trait.Sorcerer) return; // Do nothing if you're already this class. This feat will be removed in the next cycle due to a failed prerequisite anyway.
       sheet.SpellTraditionsKnown.Add(spellList);
       sheet.SpellRepertoires.Add(Trait.Sorcerer, new SpellRepertoire(Ability.Charisma, spellList));
       sheet.SetProficiency(Trait.Spell, Proficiency.Trained);

--- a/Bard.cs
+++ b/Bard.cs
@@ -217,7 +217,7 @@ namespace Dawnsbury.Mods.DawnniExpanded
 
     })).WithCustomName("Hymn of Healing")
     .WithIllustration(SpellHymnOfHealing.SpellIllustration)
-    .WithRulesBlockForSpell(SpellHymnOfHealing.Id);
+    .WithRulesBlockForSpell(SpellHymnOfHealing.Id, Trait.Bard);
 
     public static Feat TripleTime = new TrueFeat(FeatName.CustomFeat, 4, "You imbue your music with melodies which speed up you and your allies.",
     "You learn the {i}triple time{/i} composition cantrip.", new Trait[2]
@@ -232,7 +232,7 @@ namespace Dawnsbury.Mods.DawnniExpanded
       values.AddFocusSpellAndFocusPoint(Trait.Bard, Ability.Charisma, SpellTripleTime.Id);
     })).WithCustomName("Triple Time")
     .WithIllustration(SpellTripleTime.SpellIllustration)
-    .WithRulesBlockForSpell(SpellTripleTime.Id);
+    .WithRulesBlockForSpell(SpellTripleTime.Id, Trait.Bard);
 
 
     public static Feat LingeringComposition = new TrueFeat(FeatName.CustomFeat, 1, "You add a flourish to your composition to extend its benefits.", "If your next action is to cast a cantrip composition with a duration of 1 round, attempt a check using your performance skill. The DC is usually a standard-difficulty DC of a level  The effect depends on the result of your check.", new Trait[7]

--- a/Bard.cs
+++ b/Bard.cs
@@ -217,7 +217,7 @@ namespace Dawnsbury.Mods.DawnniExpanded
 
     })).WithCustomName("Hymn of Healing")
     .WithIllustration(SpellHymnOfHealing.SpellIllustration)
-    .WithRulesBlockForSpell(SpellHymnOfHealing.Id, Trait.Bard);
+    .WithRulesBlockForSpell(SpellHymnOfHealing.Id);
 
     public static Feat TripleTime = new TrueFeat(FeatName.CustomFeat, 4, "You imbue your music with melodies which speed up you and your allies.",
     "You learn the {i}triple time{/i} composition cantrip.", new Trait[2]
@@ -232,7 +232,7 @@ namespace Dawnsbury.Mods.DawnniExpanded
       values.AddFocusSpellAndFocusPoint(Trait.Bard, Ability.Charisma, SpellTripleTime.Id);
     })).WithCustomName("Triple Time")
     .WithIllustration(SpellTripleTime.SpellIllustration)
-    .WithRulesBlockForSpell(SpellTripleTime.Id, Trait.Bard);
+    .WithRulesBlockForSpell(SpellTripleTime.Id);
 
 
     public static Feat LingeringComposition = new TrueFeat(FeatName.CustomFeat, 1, "You add a flourish to your composition to extend its benefits.", "If your next action is to cast a cantrip composition with a duration of 1 round, attempt a check using your performance skill. The DC is usually a standard-difficulty DC of a level  The effect depends on the result of your check.", new Trait[7]


### PR DESCRIPTION
Telemetry for Dawnsbury Days shows two exceptions that have been happening for people with DawnniExpanded:

1. When you select an archetype but don't have any class selected, the game crashed with null reference exception. This PR fixes this issue by moving the `?.` operator in the proper places in archetype feat prerequisites.
2. When you select an archetype with spontaneous spellcasting, then select the class of that archetype, for one recalculation, the character has both that class and that archetype feat (the feat's prerequisites are no longer met, but due to the way prerequisites work in PF2E and Dawnsbury Days, that is checked only at the end of that level's recalculation). This causes a "key already exists" exceptions because both the class and the archetype attempt to add the same spell repertoire to the character. This PR fixes also this issue.

I tested this afterwards for all three spontaneous spellcaster classes and it looked to me like these bugs were fixed by this PR, but I didn't do extensive testing.

Still, please review the PR and when you're happy with it, upload a new version to the Steam Workshop to reduce the number of crashes from DawnniExpanded.