### PR TITLE
Handle another mod implementing ConcordantChoir

### DIFF
--- a/Spells/Spell.ConcordantChoir.cs
+++ b/Spells/Spell.ConcordantChoir.cs
@@ -80,11 +80,15 @@ public class SpellConcordantChoir
     }
     public static void LoadMod()
     {
-
-
-        Id = ModManager.RegisterNewSpell("ConcordantChoir", 1, (spellId, spellcaster, spellLevel, inCombat, SpellInformation) => MakeConcordantChoirSpell(spellcaster, spellLevel, inCombat)
-        );
-
+        try
+        {
+            Id = ModManager.RegisterNewSpell("ConcordantChoir", 1, (spellId, spellcaster, spellLevel, inCombat, SpellInformation) => MakeConcordantChoirSpell(spellcaster, spellLevel, inCombat));
+        }
+        catch (System.ArgumentException ex)
+        {
+            Dawnsbury.IO.GeneralLog.Log("Skipped registering spell \"ConcordantChoir\". This spell may already be provided by another mod.\n" + ex.ToString());
+            Id = SpellId.None;
+        }
     }
 }
 


### PR DESCRIPTION
Handle the situation where the ConcordantChoir spell is already provided by another mod. In this case, we use the first version registered.